### PR TITLE
 Docker file for BOUT++ with performance-optimized flags set

### DIFF
--- a/bout-optimized.dkr
+++ b/bout-optimized.dkr
@@ -35,7 +35,7 @@ RUN yum install -y wget make file gcc-c++ \
  && tar -xzvf mpich-3.2.1.tar.gz \
  && rm mpich-3.2.1.tar.gz \
  && cd mpich-3.2.1 \
- && ./configure --enable-shared \
+ && ./configure --enable-shared --enable-fast=all,O3 \
  && make \
  && make install \
  && cd / \

--- a/bout-optimized.dkr
+++ b/bout-optimized.dkr
@@ -144,7 +144,7 @@ RUN python3 -m pip install cython ipython
 # Build and install BOUT++
 # ----------------------------------------------------------------
 WORKDIR /opt
-RUN git clone -b v4.2.2 --depth 1 git://github.com/boutproject/BOUT-dev.git BOUT-dev
+RUN git clone -b v4.2.2 --depth 1 https://github.com/boutproject/BOUT-dev.git BOUT-dev
 
 WORKDIR /opt/BOUT-dev
 RUN ./configure --with-petsc PETSC_DIR=/petsc-3.9.3 PETSC_ARCH=arch-linux2-cxx-opt --with-sundials=/usr/ --with-fftw --with-netcdf --enable-openmp --with-slepc --with-lapack LIBS="-llapack -lblas" --localedir=$PWD/locale --enable-shared --enable-checks=no --enable-track=no --enable-optimize=3 \

--- a/bout-optimized.dkr
+++ b/bout-optimized.dkr
@@ -79,17 +79,17 @@ RUN yum install -y bison flex \
 --download-parmetis=1 --download-ptscotch=1 --download-metis=1 --with-sundials-dir=/usr \
 --with-debugging=no --COPTFLAGS="-O3" --CXXOPTFLAGS="-O3" --FOPTFLAGS="-O3" \
  && make -f /petsc-3.9.3/makefile all \
- && make -f /petsc-3.9.3/makefile PETSC_DIR=/petsc-3.9.3 PETSC_ARCH=arch-linux2-cxx-debug test \
- && ln -s /petsc-3.9.3/arch-linux2-cxx-debug/include/* /usr/include/ \
- && ln -s /petsc-3.9.3/arch-linux2-cxx-debug/lib/*a /usr/lib/ \
- && ln -s /petsc-3.9.3/arch-linux2-cxx-debug/lib/modules/* /usr/lib/modules/ \
- && cd /petsc-3.9.3/arch-linux2-cxx-debug/ \
+ && make -f /petsc-3.9.3/makefile PETSC_DIR=/petsc-3.9.3 PETSC_ARCH=arch-linux2-cxx-opt test \
+ && ln -s /petsc-3.9.3/arch-linux2-cxx-opt/include/* /usr/include/ \
+ && ln -s /petsc-3.9.3/arch-linux2-cxx-opt/lib/*a /usr/lib/ \
+ && ln -s /petsc-3.9.3/arch-linux2-cxx-opt/lib/modules/* /usr/lib/modules/ \
+ && cd /petsc-3.9.3/arch-linux2-cxx-opt/ \
  && rm -r externalpackages obj \
  && cd /petsc-3.9.3/ \
  && rm -r src
 
 ENV PETSC_DIR=/petsc-3.9.3/
-ENV PETSC_ARCH=arch-linux2-cxx-debug
+ENV PETSC_ARCH=arch-linux2-cxx-opt
 
 #####################
 # Install SLEPC
@@ -98,11 +98,11 @@ RUN wget http://slepc.upv.es/download/distrib/slepc-3.9.2.tar.gz \
  && tar xzf slepc-3.9.2.tar.gz \
  && rm slepc-3.9.2.tar.gz \
  && cd slepc-3.9.2/ \
- && ./configure --with-debugging=no --CFLAGS="-O3" \
- && make SLEPC_DIR=$PWD PETSC_DIR=/petsc-3.9.3/ PETSC_ARCH=arch-linux2-cxx-debug \
+ && ./configure \
+ && make SLEPC_DIR=$PWD PETSC_DIR=/petsc-3.9.3/ PETSC_ARCH=arch-linux2-cxx-opt \
  && export SLEPC_DIR=/slepc-3.9.2 \
  && make test \
- && rm -r /slepc-3.9.2/arch-linux2-cxx-debug/obj \
+ && rm -r /slepc-3.9.2/arch-linux2-cxx-opt/obj \
  && rm -r /slepc-3.9.2/src
  
 ENV SLEPC_DIR=/slepc-3.9.2
@@ -147,7 +147,7 @@ WORKDIR /opt
 RUN git clone -b v4.2.2 --depth 1 git://github.com/boutproject/BOUT-dev.git BOUT-dev
 
 WORKDIR /opt/BOUT-dev
-RUN ./configure --with-petsc PETSC_DIR=/petsc-3.9.3 PETSC_ARCH=arch-linux2-cxx-debug --with-sundials=/usr/ --with-fftw --with-netcdf --enable-openmp --with-slepc --with-lapack LIBS="-llapack -lblas" --localedir=$PWD/locale --enable-shared --enable-checks=no --enable-track=no --enable-optimize=3 \
+RUN ./configure --with-petsc PETSC_DIR=/petsc-3.9.3 PETSC_ARCH=arch-linux2-cxx-opt --with-sundials=/usr/ --with-fftw --with-netcdf --enable-openmp --with-slepc --with-lapack LIBS="-llapack -lblas" --localedir=$PWD/locale --enable-shared --enable-checks=no --enable-track=no --enable-optimize=3 \
  && make \
  && make python
 

--- a/bout-optimized.dkr
+++ b/bout-optimized.dkr
@@ -77,6 +77,7 @@ RUN yum install -y bison flex \
  && ./configure --with-clanguage=cxx --with-mpi=yes --with-shared-libraries --with-precision=double --with-scalar-type=real \
 --download-mumps=1 --download-scalapack=1 --download-blacs=1 --download-fblas-lapack=1 \
 --download-parmetis=1 --download-ptscotch=1 --download-metis=1 --with-sundials-dir=/usr \
+--with-debugging=no --COPTFLAGS="-O3" --CXXOPTFLAGS="-O3" --FOPTFLAGS="-O3" \
  && make -f /petsc-3.9.3/makefile all \
  && make -f /petsc-3.9.3/makefile PETSC_DIR=/petsc-3.9.3 PETSC_ARCH=arch-linux2-cxx-debug test \
  && ln -s /petsc-3.9.3/arch-linux2-cxx-debug/include/* /usr/include/ \
@@ -97,7 +98,7 @@ RUN wget http://slepc.upv.es/download/distrib/slepc-3.9.2.tar.gz \
  && tar xzf slepc-3.9.2.tar.gz \
  && rm slepc-3.9.2.tar.gz \
  && cd slepc-3.9.2/ \
- && ./configure \
+ && ./configure --with-debugging=no --CFLAGS="-O3" \
  && make SLEPC_DIR=$PWD PETSC_DIR=/petsc-3.9.3/ PETSC_ARCH=arch-linux2-cxx-debug \
  && export SLEPC_DIR=/slepc-3.9.2 \
  && make test \

--- a/bout-optimized.dkr
+++ b/bout-optimized.dkr
@@ -1,0 +1,160 @@
+# ================================================================================
+#             Dockerfile to setup build environment for BOUT++ master branch
+#
+# Build example: sudo docker build -t boutproject/release:4.2 -f bout.dkr .
+#
+# ================================================================================
+FROM centos:centos7
+MAINTAINER Jarrod Leddy "jleddy@txcorp.com"
+
+# ----------------------------------------------------------------
+# Convenient network/system tools, python, dependencies
+# ----------------------------------------------------------------
+RUN yum install -y emacs-nox vim nano git gfortran g++ gcc \
+ mpich fftw-devel hdf5 blas-devel lapack-devel cmake zlib-devel hdf5-devel sudo \
+ && yum clean all \
+ && rm -rf /var/cache/yum
+
+# ----------------------------------------------------------------
+# Python
+# ----------------------------------------------------------------
+RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm \
+    && yum install -y python36u python36u-pip python36u-devel \
+    && ln -s /usr/bin/python3.6 /usr/bin/python3 \
+    && python3 -m pip install numpy scipy netcdf4 matplotlib
+
+# ----------------------------------------------------------------
+# Get BOUT++ dependencies
+# ----------------------------------------------------------------
+
+#####################
+# Install mpich
+WORKDIR /
+RUN yum install -y wget make file gcc-c++ \
+ && wget https://www.mpich.org/static/tarballs/3.2.1/mpich-3.2.1.tar.gz \
+ && tar -xzvf mpich-3.2.1.tar.gz \
+ && rm mpich-3.2.1.tar.gz \
+ && cd mpich-3.2.1 \
+ && ./configure --enable-shared \
+ && make \
+ && make install \
+ && cd / \
+ && rm -r mpich-3.2.1
+
+#####################
+# Install SUNDIALS
+
+WORKDIR /
+RUN wget https://computation.llnl.gov/projects/sundials/download/sundials-2.7.0.tar.gz \
+ && tar -xvzf sundials-2.7.0.tar.gz \
+ && rm sundials-2.7.0.tar.gz \
+ && cd sundials-2.7.0 \
+ && mkdir build \
+ && mkdir -p /usr/examples \
+ && cd build/ \
+ && cmake \
+  -DCMAKE_INSTALL_PREFIX=/usr/ \
+  -DEXAMPLES_INSTALL_PATH=/usr/examples \
+  -DCMAKE_LINKER=/usr/lib \
+  -DLAPACK_ENABLE=ON \
+  -DOPENMP_ENABLE=ON \
+  -DBUILD_SHARED_LIBS=ON \
+  -DMPI_ENABLE=ON \
+  ../  \
+ && make \
+ && make install \
+ && cd / \
+ && rm -r sundials-2.7.0
+
+#####################
+# Install PETSC
+
+WORKDIR /
+RUN yum install -y bison flex \
+ && wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.9.3.tar.gz \
+ && tar -xvzf petsc-lite-3.9.3.tar.gz \
+ && cd petsc-3.9.3/ \
+ && ./configure --with-clanguage=cxx --with-mpi=yes --with-shared-libraries --with-precision=double --with-scalar-type=real \
+--download-mumps=1 --download-scalapack=1 --download-blacs=1 --download-fblas-lapack=1 \
+--download-parmetis=1 --download-ptscotch=1 --download-metis=1 --with-sundials-dir=/usr \
+ && make -f /petsc-3.9.3/makefile all \
+ && make -f /petsc-3.9.3/makefile PETSC_DIR=/petsc-3.9.3 PETSC_ARCH=arch-linux2-cxx-debug test \
+ && ln -s /petsc-3.9.3/arch-linux2-cxx-debug/include/* /usr/include/ \
+ && ln -s /petsc-3.9.3/arch-linux2-cxx-debug/lib/*a /usr/lib/ \
+ && ln -s /petsc-3.9.3/arch-linux2-cxx-debug/lib/modules/* /usr/lib/modules/ \
+ && cd /petsc-3.9.3/arch-linux2-cxx-debug/ \
+ && rm -r externalpackages obj \
+ && cd /petsc-3.9.3/ \
+ && rm -r src
+
+ENV PETSC_DIR=/petsc-3.9.3/
+ENV PETSC_ARCH=arch-linux2-cxx-debug
+
+#####################
+# Install SLEPC
+WORKDIR /
+RUN wget http://slepc.upv.es/download/distrib/slepc-3.9.2.tar.gz \
+ && tar xzf slepc-3.9.2.tar.gz \
+ && rm slepc-3.9.2.tar.gz \
+ && cd slepc-3.9.2/ \
+ && ./configure \
+ && make SLEPC_DIR=$PWD PETSC_DIR=/petsc-3.9.3/ PETSC_ARCH=arch-linux2-cxx-debug \
+ && export SLEPC_DIR=/slepc-3.9.2 \
+ && make test \
+ && rm -r /slepc-3.9.2/arch-linux2-cxx-debug/obj \
+ && rm -r /slepc-3.9.2/src
+ 
+ENV SLEPC_DIR=/slepc-3.9.2
+
+#####################
+# Install NETCDF
+WORKDIR /
+RUN yum install -y zlib-devel hdf5-devel \
+ && wget https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-4.6.1.tar.gz \
+ && tar -xzvf netcdf-4.6.1.tar.gz \
+ && rm netcdf-4.6.1.tar.gz \
+ && cd /netcdf-4.6.1/ \
+ && ./configure --prefix=/usr/local --disable-dap --enable-parallel --enable-shared \
+ && make \
+ && make install \
+ && cd / \
+ && rm -r netcdf-4.6.1
+
+#####################
+# Install NETCDF-cxx
+WORKDIR /
+
+RUN wget https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx4-4.3.0.tar.gz \
+ && tar -xzvf netcdf-cxx4-4.3.0.tar.gz \
+ && rm netcdf-cxx4-4.3.0.tar.gz \
+ && cd netcdf-cxx4-4.3.0/ \
+ && ./configure --prefix=/usr/local --enable-shared \
+ && make \
+ && make install \
+ && cd / \
+ && rm -r netcdf-cxx4-4.3.0
+
+####################
+# Cython
+
+RUN python3 -m pip install cython ipython
+
+# ----------------------------------------------------------------
+# Build and install BOUT++
+# ----------------------------------------------------------------
+WORKDIR /opt
+RUN git clone -b v4.2.2 --depth 1 git://github.com/boutproject/BOUT-dev.git BOUT-dev
+
+WORKDIR /opt/BOUT-dev
+RUN ./configure --with-petsc PETSC_DIR=/petsc-3.9.3 PETSC_ARCH=arch-linux2-cxx-debug --with-sundials=/usr/ --with-fftw --with-netcdf --enable-openmp --with-slepc --with-lapack LIBS="-llapack -lblas" --localedir=$PWD/locale --enable-shared --enable-checks=no --enable-track=no --enable-optimize=3 \
+ && make \
+ && make python
+
+ENV PYTHONPATH=/opt/BOUT-dev/tools/pylib/:$PYTHONPATH
+ENV PYTHONIOENCODING=utf-8
+
+RUN git submodule update --init --recursive \
+ && make check-unit-tests \
+ && make clean-unit-tests \
+ && rm tests/unit/serial_tests \
+ && make clean-remove-object-files

--- a/bout-optimized.dkr
+++ b/bout-optimized.dkr
@@ -54,9 +54,9 @@ RUN wget https://computation.llnl.gov/projects/sundials/download/sundials-2.7.0.
  && cd build/ \
  && cmake \
   -DCMAKE_INSTALL_PREFIX=/usr/ \
-  -DEXAMPLES_INSTALL_PATH=/usr/examples \
+  -DCMAKEBUILDTYPE=Release \
+  -DEXAMPLES_INSTALL=OFF \
   -DCMAKE_LINKER=/usr/lib \
-  -DLAPACK_ENABLE=ON \
   -DOPENMP_ENABLE=ON \
   -DBUILD_SHARED_LIBS=ON \
   -DMPI_ENABLE=ON \


### PR DESCRIPTION
A version of the docker file with `--enable-checks=no --enable-track=no --enable-optimize=3` passed to `configure` seems like it would be useful. I've also tried to pass sensible optimization flags to mpich, sundials and petsc/slepc.

I'm not sure how many docker files it's useful to keep in this repo? I also made for myself variants using openmpi (or openmpi3) and replacing sundials-2.7.0 with sundials-4.1.0. I could make PRs for those variants if anyone would find them useful.