### PR TITLE
Replace git:// with https:// in github.com paths

### DIFF
--- a/bout-next-sundials-ubuntu.dkr
+++ b/bout-next-sundials-ubuntu.dkr
@@ -72,8 +72,8 @@ RUN useradd -ms /bin/bash boutuser \
 USER boutuser
 WORKDIR /home/boutuser
 
-#RUN git clone -b next --depth 1 git://github.com/boutproject/BOUT-dev.git BOUT-next \
-RUN git clone -b sundials-extra-libs --depth 1 git://github.com/boutproject/BOUT-dev.git BOUT-next \
+#RUN git clone -b next --depth 1 https://github.com/boutproject/BOUT-dev.git BOUT-next \
+RUN git clone -b sundials-extra-libs --depth 1 https://github.com/boutproject/BOUT-dev.git BOUT-next \
  && chown boutuser /home/boutuser/BOUT-next
 
 WORKDIR /home/boutuser/BOUT-next

--- a/bout-next.dkr
+++ b/bout-next.dkr
@@ -150,7 +150,7 @@ RUN useradd -ms /bin/bash boutuser \
 USER boutuser
 WORKDIR /home/boutuser
 
-RUN git clone -b next --depth 1 git://github.com/boutproject/BOUT-dev.git BOUT-next \
+RUN git clone -b next --depth 1 https://github.com/boutproject/BOUT-dev.git BOUT-next \
  && chown boutuser /home/boutuser/BOUT-next
 
 WORKDIR /home/boutuser/BOUT-next

--- a/bout.dkr
+++ b/bout.dkr
@@ -143,7 +143,7 @@ RUN python3 -m pip install cython ipython
 # Build and install BOUT++
 # ----------------------------------------------------------------
 WORKDIR /opt
-RUN git clone -b v4.2.2 --depth 1 git://github.com/boutproject/BOUT-dev.git BOUT-dev
+RUN git clone -b v4.2.2 --depth 1 https://github.com/boutproject/BOUT-dev.git BOUT-dev
 
 WORKDIR /opt/BOUT-dev
 RUN ./configure --with-petsc PETSC_DIR=/petsc-3.9.3 PETSC_ARCH=arch-linux2-cxx-debug --with-sundials=/usr/ --with-fftw --with-netcdf --enable-openmp --with-cvode --with-arkode --with-slepc --with-lapack LIBS="-llapack -lblas" --localedir=$PWD/locale --enable-shared \


### PR DESCRIPTION
The `git://` protocol does not work for me. Probably because of the company firewall. I had to replace it with `https://`. Maybe this is a useful change? If I understand right, the git protocol is supposed to have better performance, but this repo is small anyway. https may be more robust when accessing through firewalls, so I made this PR. No strong opinion on whether it should go in though - we could just put a note in the README.md instead.